### PR TITLE
feat: added application Tags into the report

### DIFF
--- a/ServicePrincipalExpirationReport.ps1
+++ b/ServicePrincipalExpirationReport.ps1
@@ -14,11 +14,13 @@ Function Get-AZSPReport
             $Currentdate = Get-Date
             $diffDays = (New-TimeSpan -Start $Currentdate -End $EndDate).Days
             $status = $(if ($diffDays -le $days) { "WARNING" } else { "OK" })
+            $tags = ($ADSP.Tag | Join-String -Separator ",")
     
             $SPReport = New-Object PSObject
             $SPReport | Add-Member -type NoteProperty -name Status -Value $status
             $SPReport | Add-Member -type NoteProperty -name DisplayName -Value $ADSP.DisplayName
             $SPReport | Add-Member -type NoteProperty -name AppID -Value $ADSP.AppID
+            $SPReport | Add-Member -type NoteProperty -name Tags -Value $tags
             $SPReport | Add-Member -type NoteProperty -name StartDate -Value $AZADAppCred.StartDateTime
             $SPReport | Add-Member -type NoteProperty -name EndDate -Value $AZADAppCred.EndDateTime
             $SPReport | Add-Member -type NoteProperty -name DaysToExpire -Value $diffDays


### PR DESCRIPTION
* Added Azure Application Tags into the report
* Tags are separated by `","`
* Should allow for for further and easier filtering by monitoring tools

Example:
```json
[{
  "Status":"OK",
  "DisplayName":"Bratislava production",
  "AppID":"bb256d2c-a521-41b0b21e-271390d8ca41",
  "Tags":"supportsConvergence:true,availableToOtherTenants:true,accessTokenVersion:1,appModelVersion:2",
  "StartDate":"2017-11-29T07:56:31.1240481Z",
  "EndDate":"2099-12-31T12:00:00Z",
  "DaysToExpire":27645,
  "Type":"Secret"
}]
```